### PR TITLE
Add tests to check that bad protobuf message are rejected.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+coverage.out
+coverage.html

--- a/Makefile
+++ b/Makefile
@@ -15,5 +15,4 @@
 .PHONY: test
 test:
 	go test -cover -covermode=count -coverprofile=coverage.out .
-	sed -i "s/_$${PWD//\//\\\/}/./" coverage.out
 	go tool cover -html=coverage.out -o coverage.html

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,19 @@
+# Copyright 2017 The ObjectHash-Proto Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+.PHONY: test
+test:
+	go test -cover -covermode=count -coverprofile=coverage.out .
+	sed -i "s/_$${PWD//\//\\\/}/./" coverage.out
+	go tool cover -html=coverage.out -o coverage.html

--- a/functional_test.go
+++ b/functional_test.go
@@ -1,0 +1,31 @@
+// Copyright 2017 The ObjectHash-Proto Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package protohash
+
+import "testing"
+
+import "./tests"
+
+func TestFunctional(t *testing.T) {
+	protoHashers := tests.ProtoHashers{
+		DefaultHasher:                 NewHasher(),
+		FieldNamesAsKeysHasher:        NewHasher(FieldNamesAsKeys()),
+		EnumsAsStringsHasher:          NewHasher(EnumsAsStrings()),
+		StringPreferringHasher:        NewHasher(FieldNamesAsKeys(), EnumsAsStrings()),
+		CustomMessageIdentifierHasher: NewHasher(MessageIdentifier(`m`)),
+	}
+
+	t.Run("TestBadness", func(t *testing.T) { tests.TestBadness(t, protoHashers) })
+}

--- a/functional_test.go
+++ b/functional_test.go
@@ -16,7 +16,7 @@ package protohash
 
 import "testing"
 
-import "./tests"
+import "github.com/deepmind/objecthash-proto/tests"
 
 func TestFunctional(t *testing.T) {
 	protoHashers := tests.ProtoHashers{

--- a/tests/badness_detection.go
+++ b/tests/badness_detection.go
@@ -1,0 +1,60 @@
+// Copyright 2017 The ObjectHash-Proto Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tests
+
+import (
+	"testing"
+
+	pb2_latest "../test_protos/generated/latest/proto2"
+	pb3_latest "../test_protos/generated/latest/proto2"
+
+	"github.com/golang/protobuf/proto"
+)
+
+func TestBadness(t *testing.T, hashers ProtoHashers) {
+	hasher := hashers.DefaultHasher
+
+	badProtos := []proto.Message{
+		// Nil messages in repeated fields are bad.
+		&pb2_latest.Repetitive{SimpleField: []*pb2_latest.Simple{nil}},
+		&pb3_latest.Repetitive{SimpleField: []*pb3_latest.Simple{nil}},
+
+		// Nil messages in maps are bad.
+		&pb2_latest.IntMaps{IntToSimple: map[int64]*pb2_latest.Simple{3: nil}},
+		&pb3_latest.IntMaps{IntToSimple: map[int64]*pb3_latest.Simple{3: nil}},
+
+		// Custom default values are bad.
+		&pb2_latest.BadWithDefaults{},
+
+		&pb2_latest.BadWithDefaults{Text: proto.String("Schlecht!")},
+
+		// Required fields are bad.
+		&pb2_latest.BadWithRequirements{},
+
+		&pb2_latest.BadWithRequirements{Text: proto.String("Schlecht!")},
+
+		// Extensions are bad.
+		&pb2_latest.BadWithExtensions{},
+
+		// Create proto messages with unknown fields. That's bad.
+		forgetAllFields(&pb2_latest.PersonV1{Name: proto.String("Unbekannt")}),
+	}
+	for _, message := range badProtos {
+		_, err := hasher.HashProto(message)
+		if err == nil {
+			t.Errorf("Attempting to hash %T{ %+v} should have returned an error.", message, message)
+		}
+	}
+}

--- a/tests/badness_detection.go
+++ b/tests/badness_detection.go
@@ -17,8 +17,8 @@ package tests
 import (
 	"testing"
 
-	pb2_latest "../test_protos/generated/latest/proto2"
-	pb3_latest "../test_protos/generated/latest/proto2"
+	pb2_latest "github.com/deepmind/objecthash-proto/test_protos/generated/latest/proto2"
+	pb3_latest "github.com/deepmind/objecthash-proto/test_protos/generated/latest/proto2"
 
 	"github.com/golang/protobuf/proto"
 )

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -15,7 +15,7 @@
 package tests
 
 import (
-	pb2_latest "../test_protos/generated/latest/proto2"
+	pb2_latest "github.com/deepmind/objecthash-proto/test_protos/generated/latest/proto2"
 
 	"github.com/golang/protobuf/proto"
 )

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -1,0 +1,48 @@
+// Copyright 2017 The ObjectHash-Proto Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tests
+
+import (
+	pb2_latest "../test_protos/generated/latest/proto2"
+
+	"github.com/golang/protobuf/proto"
+)
+
+type ProtoHasher interface {
+	HashProto(pb proto.Message) ([]byte, error)
+}
+
+type ProtoHashers struct {
+	DefaultHasher                 ProtoHasher
+	FieldNamesAsKeysHasher        ProtoHasher
+	EnumsAsStringsHasher          ProtoHasher
+	StringPreferringHasher        ProtoHasher
+	CustomMessageIdentifierHasher ProtoHasher
+}
+
+func forgetAllFields(originalMessage proto.Message) proto.Message {
+	emptyMessage := &pb2_latest.Empty{}
+
+	binaryMessage, err := proto.Marshal(originalMessage)
+	if err != nil {
+		panic(err)
+	}
+
+	err = proto.Unmarshal(binaryMessage, emptyMessage)
+	if err != nil {
+		panic(err)
+	}
+	return emptyMessage
+}


### PR DESCRIPTION
Also:
- Add a Makefile and a Make target for running tests.
- Add a `tests` directory/package for functional tests of the library.
- Add `functional_test.go` which will be used to run all the functional
  tests in the `tests` directory/package as part of the full test suite.
- Add some helpful utility functions to the `tests` package to simplify
  writing functional tests.
- Make sure that the library rejects invalid protos as well as protos
  with required fields or explicit default values.