### PR TITLE
Remove backticks from documentation comments.

### DIFF
--- a/detection.go
+++ b/detection.go
@@ -23,9 +23,9 @@ import (
 	"github.com/golang/protobuf/proto"
 )
 
-// `isAny` checks if a value is a `google.protobuf.Any` message.
+// isAny checks if a value is a google.protobuf.Any message.
 //
-// This is done by calling `XXX_WellKnownType` on the value and checking if it
+// This is done by calling XXX_WellKnownType on the value and checking if it
 // returns the string "Any".
 func isAny(sv reflect.Value) bool {
 	type wktProto interface {
@@ -33,14 +33,14 @@ func isAny(sv reflect.Value) bool {
 		XXX_WellKnownType() string
 	}
 
-	// The method `XXX_WellKnownType` requires a pointer receiver.
+	// The method XXX_WellKnownType requires a pointer receiver.
 	wellKnownValue, ok := sv.Addr().Interface().(wktProto)
 	return ok && wellKnownValue.XXX_WellKnownType() == "Any"
 }
 
-// `isExtendable` checks if the proto message is extendable.
+// isExtendable checks if the proto message is extendable.
 //
-// This is done by checking if it has the `ExtensionRangeArray` method.
+// This is done by checking if it has the ExtensionRangeArray method.
 func isExtendable(sv reflect.Value) bool {
 	type extendableProto interface {
 		proto.Message
@@ -51,9 +51,9 @@ func isExtendable(sv reflect.Value) bool {
 	return ok
 }
 
-// `isRawMessageField` checks if the proto field is a RawMessage.
+// isRawMessageField checks if the proto field is a RawMessage.
 //
-// This is done by checking if it has the `Bytes` method.
+// This is done by checking if it has the Bytes method.
 func isRawMessageField(v reflect.Value) bool {
 	type rawMessageField interface {
 		Bytes() []byte
@@ -63,7 +63,7 @@ func isRawMessageField(v reflect.Value) bool {
 	return ok
 }
 
-// `isAOneOfField` checks if the proto field is a `oneof` wrapper field.
+// isAOneOfField checks if the proto field is a oneof wrapper field.
 //
 // This is done by checking if it is an interface whose tag has a
 // "protobuf_oneof" entry.
@@ -71,7 +71,7 @@ func isAOneOfField(v reflect.Value, sf reflect.StructField) bool {
 	return v.Kind() == reflect.Interface && sf.Tag.Get("protobuf_oneof") != ""
 }
 
-// `isUnset` checks if the proto field has not been set.
+// isUnset checks if the proto field has not been set.
 //
 // This also includes empty proto3 scalar values.
 func isUnset(v reflect.Value) (bool, error) {
@@ -131,23 +131,23 @@ func isUnset(v reflect.Value) (bool, error) {
 		// This should never happen because protobuf generated code never uses structs
 		// as fields, and uses pointers to structs instead.
 		// This means that emptiness checks for nested messages would happen in the
-		// `reflect.Ptr` case rather than here.
+		// reflect.Ptr case rather than here.
 		return false, fmt.Errorf("Got an unexpected struct type: %T", v)
 	default:
 		return false, fmt.Errorf("Unsupported type: %T", v)
 	}
 }
 
-// `failIfUnsupported` returns an error if the provided field cannot be hashed reliably.
+// failIfUnsupported returns an error if the provided field cannot be hashed reliably.
 //
 // Note that unsupported fields are safe to ignore if they've not been set, so
-// an `isUnset` check should be used before this check.
+// an isUnset check should be used before this check.
 func failIfUnsupported(v reflect.Value, sf reflect.StructField) error {
 	// Check "XXX_" fields.
 	if name := sf.Name; strings.HasPrefix(name, "XXX_") {
 		switch name {
 		case "XXX_unrecognized":
-			// A non-empty `XXX_unrecognized` field means that the proto message
+			// A non-empty XXX_unrecognized field means that the proto message
 			// contains some unrecognized fields.
 			return errors.New("Unrecognized fields cannot be hashed reliably.")
 		case "XXX_extensions", "XXX_InternalExtensions":

--- a/manipulation.go
+++ b/manipulation.go
@@ -20,7 +20,7 @@ import (
 	"reflect"
 )
 
-// `stringify` returns a string representation of a `reflect.Value` object.
+// stringify returns a string representation of a reflect.Value object.
 func stringify(v reflect.Value) (string, error) {
 	if !v.IsValid() {
 		return "", errors.New("Encountered a null pointer.")
@@ -34,6 +34,6 @@ func stringify(v reflect.Value) (string, error) {
 	if ok {
 		return stringerValue.String(), nil
 	} else {
-		return "", fmt.Errorf("Failed to represent value '%v' as a string because it does not have a `String()` method", v)
+		return "", fmt.Errorf("Failed to represent value '%v' as a string because it does not have a 'String()' method", v)
 	}
 }

--- a/object_hasher.go
+++ b/object_hasher.go
@@ -24,8 +24,8 @@ import (
 	"github.com/golang/protobuf/proto"
 )
 
-// `objectHasher` is a configurable object for hashing protocol buffer objects.
-// It implements the `ProtoHasher` interface.
+// objectHasher is a configurable object for hashing protocol buffer objects.
+// It implements the ProtoHasher interface.
 type objectHasher struct {
 	// Whether to hash enum values as strings, as opposed to as integer values.
 	enumsAsStrings bool
@@ -39,7 +39,7 @@ type objectHasher struct {
 	messageIdentifier string
 }
 
-// `HashProto` returns the object hash of a given protocol buffer message.
+// HashProto returns the object hash of a given protocol buffer message.
 func (hasher *objectHasher) HashProto(pb proto.Message) (h []byte, err error) {
 	// Ensure that we can recover if the proto library panics.
 	// See: https://github.com/golang/protobuf/issues/478
@@ -197,12 +197,12 @@ func (hasher *objectHasher) hashStruct(sv reflect.Value) ([]byte, error) {
 	return hash(identifier, h.Bytes())
 }
 
-// `hashValue` returns the hash of an arbitrary proto field value.
+// hashValue returns the hash of an arbitrary proto field value.
 //
 // Note that the StructField argument is only used for types that can only
 // exist within structs (ie. repeated fields and maps). Therefore, when the
 // value does not exist within a struct, it is safe to call this function with
-// an empty StructField (ie. `reflect.StructField{}`).
+// an empty StructField (ie. reflect.StructField{}).
 func (hasher *objectHasher) hashValue(v reflect.Value, sf reflect.StructField, props *proto.Properties) ([]byte, error) {
 	switch v.Kind() {
 	case reflect.Struct:
@@ -280,7 +280,7 @@ func (hasher *objectHasher) hashOneOf(v reflect.Value, sf reflect.StructField, p
 	fieldPointer := v.Elem()                      // Get the pointer to the inner struct.
 	innerStruct := reflect.Indirect(fieldPointer) // Get the inner struct.
 
-	// This check protects `innerStruct.Field(0)` from panicing.
+	// This check protects innerStruct.Field(0) from panicing.
 	if innerStruct.Kind() != reflect.Struct || innerStruct.NumField() != 1 {
 		return hashEntry{}, fmt.Errorf("Unsupported interface type: %T. Expected it to be a oneof field.", v)
 	}

--- a/options.go
+++ b/options.go
@@ -18,7 +18,7 @@ import (
 	"fmt"
 )
 
-// An `Option` modifies how ObjectHashes for protobufs is calculated.
+// Option modifies how ObjectHashes for protobufs is calculated.
 type Option interface {
 	set(*objectHasher)
 	fmt.Stringer

--- a/protohash.go
+++ b/protohash.go
@@ -24,7 +24,7 @@ type ProtoHasher interface {
 	HashProto(pb proto.Message) ([]byte, error)
 }
 
-// Creates a new `ProtoHasher` with the options specified in the argument.
+// NewHasher creates a new ProtoHasher with the options specified in the argument.
 func NewHasher(opts ...Option) ProtoHasher {
 	hasher := objectHasher{messageIdentifier: mapIdentifier}
 	for _, opt := range opts {


### PR DESCRIPTION
This is because the go doc tooling does not process those backticks as
inline code.