### PR TITLE
Distinguish between empty and unset proto2 byte fields.

### DIFF
--- a/detection.go
+++ b/detection.go
@@ -71,10 +71,41 @@ func isAOneOfField(v reflect.Value, sf reflect.StructField) bool {
 	return v.Kind() == reflect.Interface && sf.Tag.Get("protobuf_oneof") != ""
 }
 
+// isAProto2BytesField checks if the field is a proto2 bytes field.
+//
+// This is done by checking the field's tag. Byte fields do not have a 'rep'
+// tag (for repeated fields).  Additionally, proto3 byte fields have a 'proto3'
+// tag, which proto2 byte fields do not have.
+func isAProto2BytesField(v reflect.Value, sf reflect.StructField) bool {
+	tag := sf.Tag.Get("protobuf")
+
+	// This can potentially break "def" values which come last and can contain
+	// commas. This is fine because we don't care about "def" or its value here.
+	//
+	// Example: "bytes,10,opt,name=F_String,json=FString,def=hello, \"world!\"\n"
+	fields := strings.Split(tag, ",")
+
+	// Normal proto tags (incl. bytes) will have at least 2 fields.
+	if len(fields) < 2 {
+		// We do not return an error because this case can happen for certain kinds
+		// of fields, such as 'XXX_unrecognized' for example.
+		return false
+	}
+
+	for i := 2; i < len(fields); i++ {
+		f := fields[i]
+		if f == "rep" || f == "proto3" {
+			return false
+		}
+	}
+
+	return true
+}
+
 // isUnset checks if the proto field has not been set.
 //
 // This also includes empty proto3 scalar values.
-func isUnset(v reflect.Value) (bool, error) {
+func isUnset(v reflect.Value, sf reflect.StructField) (bool, error) {
 	// Default values are considered empty. Otherwise, adding those kinds of
 	// fields to a proto's definition would break all older hashes.
 	switch v.Kind() {
@@ -89,6 +120,19 @@ func isUnset(v reflect.Value) (bool, error) {
 	case reflect.String:
 		return v.String() == "", nil
 	case reflect.Map, reflect.Slice:
+		// Proto2 bytes fields are considered scalar fields, which means that there
+		// is a distinction between unset fields and fields set to zero values.
+		//
+		// Therefore, if we encounter a proto2 bytes field, we should only check if
+		// it's nil or not, rather than checking its value.
+		if isAProto2BytesField(v, sf) {
+			return v.IsNil(), nil
+		}
+
+		// If this is not a proto2 bytes field, then empty values are always unset.
+		//
+		// This applies for: repeated fields, proto3 bytes fields, and special
+		// fields (ex. XXX_unrecognized).
 		return v.Len() == 0, nil
 	case reflect.Interface:
 		// This only happens when we have a oneof field.
@@ -132,9 +176,9 @@ func isUnset(v reflect.Value) (bool, error) {
 		// as fields, and uses pointers to structs instead.
 		// This means that emptiness checks for nested messages would happen in the
 		// reflect.Ptr case rather than here.
-		return false, fmt.Errorf("Got an unexpected struct type: %T", v)
+		return false, fmt.Errorf("got an unexpected struct type: %T", v)
 	default:
-		return false, fmt.Errorf("Unsupported type: %T", v)
+		return false, fmt.Errorf("unsupported type: %T", v)
 	}
 }
 

--- a/detection.go
+++ b/detection.go
@@ -77,6 +77,11 @@ func isAOneOfField(v reflect.Value, sf reflect.StructField) bool {
 // tag (for repeated fields).  Additionally, proto3 byte fields have a 'proto3'
 // tag, which proto2 byte fields do not have.
 func isAProto2BytesField(v reflect.Value, sf reflect.StructField) bool {
+	k := v.Kind()
+	if k != reflect.Map && k != reflect.Slice {
+		return false
+	}
+
 	tag := sf.Tag.Get("protobuf")
 
 	// This can potentially break "def" values which come last and can contain

--- a/detection_test.go
+++ b/detection_test.go
@@ -1,0 +1,42 @@
+// Copyright 2018 The ObjectHash-Proto Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package protohash
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestIsAProto2BytesFieldWithBadArguments(t *testing.T) {
+	var emptyV reflect.Value
+	var emptySF reflect.StructField
+	if isAProto2BytesField(emptyV, emptySF) {
+		t.Error("isAProto2BytesField incorrectly returned true for zero values.")
+	}
+
+	v := reflect.ValueOf(struct {
+		s string
+		i int64
+	}{"Hello", 42})
+	tp := v.Type()
+
+	if isAProto2BytesField(v.Field(0), tp.Field(0)) {
+		t.Error("isAProto2BytesField incorrectly returned true for a string.")
+	}
+
+	if isAProto2BytesField(v.Field(1), tp.Field(1)) {
+		t.Error("isAProto2BytesField incorrectly returned true for an int.")
+	}
+}

--- a/functional_test.go
+++ b/functional_test.go
@@ -33,6 +33,7 @@ func TestFunctional(t *testing.T) {
 	t.Run("TestIntegerFields", func(t *testing.T) { tests.TestIntegerFields(t, protoHashers) })
 	t.Run("TestMaps", func(t *testing.T) { tests.TestMaps(t, protoHashers) })
 	t.Run("TestOtherTypes", func(t *testing.T) { tests.TestOtherTypes(t, protoHashers) })
+	t.Run("TestProto2DefaultFieldValues", func(t *testing.T) { tests.TestProto2DefaultFieldValues(t, protoHashers) })
 	t.Run("TestRepeatedFields", func(t *testing.T) { tests.TestRepeatedFields(t, protoHashers) })
 	t.Run("TestStringFields", func(t *testing.T) { tests.TestStringFields(t, protoHashers) })
 }

--- a/object_hasher.go
+++ b/object_hasher.go
@@ -159,7 +159,7 @@ func (hasher *objectHasher) hashStruct(sv reflect.Value) ([]byte, error) {
 		sf := st.Field(i)
 
 		// Ignore unset fields (and empty proto3 scalar fields).
-		unset, err := isUnset(v)
+		unset, err := isUnset(v, sf)
 		if err != nil {
 			return nil, err
 		}

--- a/tests/proto2_default_field_values.go
+++ b/tests/proto2_default_field_values.go
@@ -1,0 +1,91 @@
+// Copyright 2018 The ObjectHash-Proto Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tests
+
+import (
+	"testing"
+
+	"github.com/golang/protobuf/proto"
+
+	pb2_latest "github.com/deepmind/objecthash-proto/test_protos/generated/latest/proto2"
+)
+
+// TestProto2DefaultFieldValues checks that proto2 default field values are properly hashed.
+func TestProto2DefaultFieldValues(t *testing.T, hashers ProtoHashers) {
+	hasher := hashers.StringPreferringHasher
+
+	testCases := []testCase{
+		{
+			protos: []proto.Message{
+				&pb2_latest.Simple{BoolField: proto.Bool(false)},
+			},
+			equivalentJSONString: "{\"bool_field\":false}",
+			equivalentObject:     map[string]bool{"bool_field": false},
+			expectedHashString:   "1ab5ecdbe4176473024f7efd080593b740d22d076d06ea6edd8762992b484a12",
+		},
+
+		{
+			protos: []proto.Message{
+				&pb2_latest.Simple{BytesField: []byte{}},
+			},
+			// No JSON equivalent because JSON does not have a "bytes" representation.
+			equivalentObject:   map[string][]byte{"bytes_field": {}},
+			expectedHashString: "10a0dbbfa097b731c7a505246ffa96a82f997b8c25892d76d3b8b1355e529e05",
+		},
+
+		{
+			protos: []proto.Message{
+				&pb2_latest.Simple{StringField: proto.String("")},
+			},
+			equivalentJSONString: "{\"string_field\":\"\"}",
+			equivalentObject:     map[string]string{"string_field": ""},
+			expectedHashString:   "2d60c2941830ef4bb14424e47c6cd010f2b95e5e34291f429998288a60ac8c22",
+		},
+
+		{
+			protos: []proto.Message{
+				&pb2_latest.Fixed32Message{Value: proto.Uint32(0)},
+				&pb2_latest.Fixed64Message{Value: proto.Uint64(0)},
+				&pb2_latest.Int32Message{Value: proto.Int32(0)},
+				&pb2_latest.Int64Message{Value: proto.Int64(0)},
+				&pb2_latest.Sfixed32Message{Value: proto.Int32(0)},
+				&pb2_latest.Sfixed64Message{Value: proto.Int64(0)},
+				&pb2_latest.Sint32Message{Value: proto.Int32(0)},
+				&pb2_latest.Sint64Message{Value: proto.Int64(0)},
+				&pb2_latest.Uint32Message{Value: proto.Uint32(0)},
+				&pb2_latest.Uint64Message{Value: proto.Uint64(0)},
+			},
+			// No JSON equivalent because JSON does not have an integer representation.
+			equivalentObject:   map[string]int64{"value": 0},
+			expectedHashString: "49f031b73dad26859ffeea8a2bb170aaf7358d2277b00c7fc7ea8edcd37e53a1",
+		},
+
+		{
+			protos: []proto.Message{
+				&pb2_latest.DoubleMessage{Value: proto.Float64(0.0)},
+				&pb2_latest.FloatMessage{Value: proto.Float32(0.0)},
+			},
+			equivalentJSONString: "{\"value\":0.0}",
+			equivalentObject:     map[string]float64{"value": 0.0},
+			expectedHashString:   "94136b0850db069dfd7bee090fc7ede48aa7da53ae3cc8514140a493818c3b91",
+		},
+	}
+
+	for _, tc := range testCases {
+		if err := tc.check(hasher); err != nil {
+			t.Errorf("%s", err)
+		}
+	}
+}


### PR DESCRIPTION
This change fixes a bug where proto2 byte fields set to an empty bytes
slice (ie. `[]byte{}`) were incorrectly considered unset.

Also, tests for all proto2 default field values were added to ensure
their correctness.