### PR TITLE
Avoid calculating object hashes for unsupported well-known types.

### DIFF
--- a/functional_test.go
+++ b/functional_test.go
@@ -35,4 +35,5 @@ func TestFunctional(t *testing.T) {
 	t.Run("TestOtherTypes", func(t *testing.T) { tests.TestOtherTypes(t, protoHashers) })
 	t.Run("TestRepeatedFields", func(t *testing.T) { tests.TestRepeatedFields(t, protoHashers) })
 	t.Run("TestStringFields", func(t *testing.T) { tests.TestStringFields(t, protoHashers) })
+	t.Run("TestWellKnownTypes", func(t *testing.T) { tests.TestWellKnownTypes(t, protoHashers) })
 }

--- a/object_hasher.go
+++ b/object_hasher.go
@@ -139,8 +139,9 @@ func (hasher *objectHasher) hashMap(v reflect.Value, sf reflect.StructField, pro
 }
 
 func (hasher *objectHasher) hashStruct(sv reflect.Value) ([]byte, error) {
-	if isAny(sv) {
-		return nil, errors.New("google.protobuf.Any messages cannot be hashed reliably")
+	_, ok := CheckWellKnownType(sv)
+	if ok {
+		return nil, errors.New("protobuf well-known types are currently unsupported")
 	}
 
 	if isExtendable(sv) {

--- a/test_protos/custom/future_well_known_type.pb.go
+++ b/test_protos/custom/future_well_known_type.pb.go
@@ -1,0 +1,32 @@
+// Copyright 2018 The ObjectHash-Proto Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package custom
+
+// FutureWellKnownType is a manually created mock proto that can be used in
+// tests as an unrecognized (or new) well known type.
+//
+// Note that this is not registered with the proto library (using init) to keep
+// things simple.
+type FutureWellKnownType struct {
+}
+
+func (m *FutureWellKnownType) Reset()                    { *m = FutureWellKnownType{} }
+func (m *FutureWellKnownType) String() string            { return "FutureWellKnownType" }
+func (*FutureWellKnownType) ProtoMessage()               {}
+func (*FutureWellKnownType) Descriptor() ([]byte, []int) { return []byte{}, []int{0} }
+func (*FutureWellKnownType) XXX_WellKnownType() string   { return "FutureWellKnownType" }
+
+// The following line is used to prevent linters from running on this file:
+// Code generated manually. DO NOT EDIT.

--- a/tests/well_known_types.go
+++ b/tests/well_known_types.go
@@ -1,0 +1,110 @@
+// Copyright 2018 The ObjectHash-Proto Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tests
+
+import (
+	"testing"
+
+	pb2_latest "github.com/deepmind/objecthash-proto/test_protos/generated/latest/proto2"
+	pb3_latest "github.com/deepmind/objecthash-proto/test_protos/generated/latest/proto3"
+
+	custom "github.com/deepmind/objecthash-proto/test_protos/custom"
+
+	any_pb "github.com/golang/protobuf/ptypes/any"
+	duration_pb "github.com/golang/protobuf/ptypes/duration"
+	struct_pb "github.com/golang/protobuf/ptypes/struct"
+	timestamp_pb "github.com/golang/protobuf/ptypes/timestamp"
+	wrappers_pb "github.com/golang/protobuf/ptypes/wrappers"
+
+	"github.com/golang/protobuf/proto"
+)
+
+// TestWellKnownTypes currently just confirms that all well-known types are
+// unsupported.  However, once those fields start to be supported, the tests
+// should be modified to reflect that.
+func TestWellKnownTypes(t *testing.T, hashers ProtoHashers) {
+	hasher := hashers.DefaultHasher
+
+	unsupportedProtos := []proto.Message{
+		&any_pb.Any{},
+		&pb2_latest.KnownTypes{AnyField: &any_pb.Any{}},
+		&pb3_latest.KnownTypes{AnyField: &any_pb.Any{}},
+
+		&wrappers_pb.BoolValue{},
+		&pb2_latest.KnownTypes{BoolValueField: &wrappers_pb.BoolValue{}},
+		&pb3_latest.KnownTypes{BoolValueField: &wrappers_pb.BoolValue{}},
+
+		&wrappers_pb.BytesValue{},
+		&pb2_latest.KnownTypes{BytesValueField: &wrappers_pb.BytesValue{}},
+		&pb3_latest.KnownTypes{BytesValueField: &wrappers_pb.BytesValue{}},
+
+		&wrappers_pb.DoubleValue{},
+		&pb2_latest.KnownTypes{DoubleValueField: &wrappers_pb.DoubleValue{}},
+		&pb3_latest.KnownTypes{DoubleValueField: &wrappers_pb.DoubleValue{}},
+
+		&duration_pb.Duration{},
+		&pb2_latest.KnownTypes{DurationField: &duration_pb.Duration{}},
+		&pb3_latest.KnownTypes{DurationField: &duration_pb.Duration{}},
+
+		&wrappers_pb.FloatValue{},
+		&pb2_latest.KnownTypes{FloatValueField: &wrappers_pb.FloatValue{}},
+		&pb3_latest.KnownTypes{FloatValueField: &wrappers_pb.FloatValue{}},
+
+		&wrappers_pb.Int32Value{},
+		&pb2_latest.KnownTypes{Int32ValueField: &wrappers_pb.Int32Value{}},
+		&pb3_latest.KnownTypes{Int32ValueField: &wrappers_pb.Int32Value{}},
+
+		&wrappers_pb.Int64Value{},
+		&pb2_latest.KnownTypes{Int64ValueField: &wrappers_pb.Int64Value{}},
+		&pb3_latest.KnownTypes{Int64ValueField: &wrappers_pb.Int64Value{}},
+
+		&struct_pb.ListValue{},
+		&pb2_latest.KnownTypes{ListValueField: &struct_pb.ListValue{}},
+		&pb3_latest.KnownTypes{ListValueField: &struct_pb.ListValue{}},
+
+		&wrappers_pb.StringValue{},
+		&pb2_latest.KnownTypes{StringValueField: &wrappers_pb.StringValue{}},
+		&pb3_latest.KnownTypes{StringValueField: &wrappers_pb.StringValue{}},
+
+		&struct_pb.Struct{},
+		&pb2_latest.KnownTypes{StructField: &struct_pb.Struct{}},
+		&pb3_latest.KnownTypes{StructField: &struct_pb.Struct{}},
+
+		&timestamp_pb.Timestamp{},
+		&pb2_latest.KnownTypes{TimestampField: &timestamp_pb.Timestamp{}},
+		&pb3_latest.KnownTypes{TimestampField: &timestamp_pb.Timestamp{}},
+
+		&wrappers_pb.UInt32Value{},
+		&pb2_latest.KnownTypes{Uint32ValueField: &wrappers_pb.UInt32Value{}},
+		&pb3_latest.KnownTypes{Uint32ValueField: &wrappers_pb.UInt32Value{}},
+
+		&wrappers_pb.UInt64Value{},
+		&pb2_latest.KnownTypes{Uint64ValueField: &wrappers_pb.UInt64Value{}},
+		&pb3_latest.KnownTypes{Uint64ValueField: &wrappers_pb.UInt64Value{}},
+
+		&struct_pb.Value{},
+		&pb2_latest.KnownTypes{ValueField: &struct_pb.Value{}},
+		&pb3_latest.KnownTypes{ValueField: &struct_pb.Value{}},
+
+		// Check that a future well-known type is unsupported by default.
+		&custom.FutureWellKnownType{},
+	}
+	for _, message := range unsupportedProtos {
+		_, err := hasher.HashProto(message)
+		if err == nil {
+			t.Errorf("Attempting to hash %T{ %+v} should have returned an error.", message, message)
+		}
+	}
+}


### PR DESCRIPTION
The well-known types provided by golang/protobuf often have special
semantics which would require using special methods for calculating
their object hash.

Therefore, this change makes sure that all well-known types are
identified and rejected to avoid inadvertently hashing them until
they're supported properly.