### PR TITLE
Make CI work for forks.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,16 @@ go:
   - 1.x
   - master
 
+before_install:
+  # Make CI work for forks.
+  - export OBJECTHASH_PATH="${GOPATH}/src/github.com/deepmind/objecthash-proto"
+  - if [ "${TRAVIS_BUILD_DIR}" != "${OBJECTHASH_PATH}" ]; then
+      mkdir -p "$(dirname "${OBJECTHASH_PATH}")";
+      mv "${TRAVIS_BUILD_DIR}" "${OBJECTHASH_PATH}";
+      export TRAVIS_BUILD_DIR="${OBJECTHASH_PATH}";
+      cd "${TRAVIS_BUILD_DIR}";
+    fi
+
 install: go get -t ./...
 
 before_script:


### PR DESCRIPTION
This is done by moving the code from the forked repo path to the
correct path, and then updating `TRAVIS_BUILD_DIR` as well as the
current working directory.