### PR TITLE
Improve the errors returned by the detection module.

### DIFF
--- a/detection.go
+++ b/detection.go
@@ -193,9 +193,9 @@ func isUnset(v reflect.Value, sf reflect.StructField) (bool, error) {
 		// as fields, and uses pointers to structs instead.
 		// This means that emptiness checks for nested messages would happen in the
 		// reflect.Ptr case rather than here.
-		return false, fmt.Errorf("got an unexpected struct type: %T", v)
+		return false, fmt.Errorf("got an unexpected struct of type '%+v' for field %+v", v.Type(), sf)
 	default:
-		return false, fmt.Errorf("unsupported type: %T", v)
+		return false, fmt.Errorf("got an unexpected type '%+v' for field %+v", v.Type(), sf)
 	}
 }
 

--- a/detection_test.go
+++ b/detection_test.go
@@ -20,23 +20,69 @@ import (
 )
 
 func TestIsAProto2BytesFieldWithBadArguments(t *testing.T) {
-	var emptyV reflect.Value
-	var emptySF reflect.StructField
-	if isAProto2BytesField(emptyV, emptySF) {
-		t.Error("isAProto2BytesField incorrectly returned true for zero values.")
-	}
+	t.Run("Zero values should return false", func(t *testing.T) {
+		var emptyV reflect.Value
+		var emptySF reflect.StructField
+		if isAProto2BytesField(emptyV, emptySF) {
+			t.Error("isAProto2BytesField incorrectly returned true for zero values.")
+		}
+	})
 
-	v := reflect.ValueOf(struct {
-		s string
-		i int64
-	}{"Hello", 42})
-	tp := v.Type()
+	t.Run("String values should return false", func(t *testing.T) {
+		v := reflect.ValueOf(struct{ s string }{"Hello"})
+		tp := v.Type()
 
-	if isAProto2BytesField(v.Field(0), tp.Field(0)) {
-		t.Error("isAProto2BytesField incorrectly returned true for a string.")
-	}
+		if isAProto2BytesField(v.Field(0), tp.Field(0)) {
+			t.Error("isAProto2BytesField incorrectly returned true for a string.")
+		}
+	})
 
-	if isAProto2BytesField(v.Field(1), tp.Field(1)) {
-		t.Error("isAProto2BytesField incorrectly returned true for an int.")
-	}
+	t.Run("Integer values should return false", func(t *testing.T) {
+		v := reflect.ValueOf(struct{ i int64 }{42})
+		tp := v.Type()
+
+		if isAProto2BytesField(v.Field(0), tp.Field(0)) {
+			t.Error("isAProto2BytesField incorrectly returned true for an int.")
+		}
+	})
+}
+
+func TestIsUnsetWithBadArguments(t *testing.T) {
+	t.Run("Should return errors for struct fields", func(t *testing.T) {
+		v := reflect.ValueOf(struct {
+			s struct{}
+		}{})
+		tp := v.Type()
+
+		_, err := isUnset(v.Field(0), tp.Field(0))
+
+		if err == nil {
+			t.Error("isUnset should have returned an error when running on a struct field.")
+		}
+
+		// Make sure that the returned error is meaningful.
+		expectedError := "got an unexpected struct of type 'struct {}' for field {Name:s PkgPath:github.com/deepmind/objecthash-proto Type:struct {} Tag: Offset:0 Index:[0] Anonymous:false}"
+		if err.Error() != expectedError {
+			t.Errorf("Expected the error returned by isUnset to be '%s'. Instead got '%s'.", expectedError, err)
+		}
+	})
+
+	t.Run("Should return errors for fields with unsupported types", func(t *testing.T) {
+		v := reflect.ValueOf(struct {
+			c chan interface{}
+		}{})
+		tp := v.Type()
+
+		_, err := isUnset(v.Field(0), tp.Field(0))
+
+		if err == nil {
+			t.Error("isUnset should have returned an error when running on a field with an unexpected type.")
+		}
+
+		// Make sure that the returned error is meaningful.
+		expectedError := "got an unexpected type 'chan interface {}' for field {Name:c PkgPath:github.com/deepmind/objecthash-proto Type:chan interface {} Tag: Offset:0 Index:[0] Anonymous:false}"
+		if err.Error() != expectedError {
+			t.Errorf("Expected the error returned by isUnset to be '%s'. Instead got '%s'.", expectedError, err)
+		}
+	})
 }


### PR DESCRIPTION
This is because the currently returned errors are misleading and
confusing.

Before this change, when compiling protos using the latest
protoc-gen-go, the following error would be returned when attempting to
hash a proto:

```
got an unexpected struct type: reflect.Value
```

With this change, the error message would be similar to the following:

```
got an unexpected struct of type 'struct {}' for field {Name:XXX_NoUnkeyedLiteral PkgPath: Type:struct {} Tag:json:"-" Offset:96 Index:[7] Anonymous:false}
```

The tests added in this change check that the errors returned match what
is expected. This is to prevent regressions in the quality of those
error messages.