### PR TITLE
Test upstream

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,11 +55,8 @@ matrix:
       env: RECOMPILE_PROTOS=true
     - go: 1.9
       env: UPDATE_DEPS=true
-    - go: 1.9
-      env: UPDATE_DEPS=true RECOMPILE_PROTOS=true
   allow_failures:
     - go: master
     - env: RECOMPILE_PROTOS=true
     - env: UPDATE_DEPS=true
-    - env: UPDATE_DEPS=true RECOMPILE_PROTOS=true
   fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,17 @@ before_install:
   - chmod +x "${GOPATH}/bin/dep"
 
 install:
-  - dep ensure
+  # Install/update dependencies.
+  - if [ "${UPDATE_DEPS}" == "true" ]; then
+      dep ensure -update;
+    else
+      dep ensure;
+    fi;
+  # Recompile protos using the latest protoc-gen-go.
+  - if [ "${RECOMPILE_PROTOS}" == "true" ]; then
+      ./test_protos/update_protos.sh;
+    fi
+
 
 before_script:
   # CodeClimate
@@ -40,6 +50,16 @@ after_script:
   - ./cc-test-reporter after-build -t gocov --exit-code $TRAVIS_TEST_RESULT
 
 matrix:
+  include:
+    - go: 1.9
+      env: RECOMPILE_PROTOS=true
+    - go: 1.9
+      env: UPDATE_DEPS=true
+    - go: 1.9
+      env: UPDATE_DEPS=true RECOMPILE_PROTOS=true
   allow_failures:
     - go: master
+    - env: RECOMPILE_PROTOS=true
+    - env: UPDATE_DEPS=true
+    - env: UPDATE_DEPS=true RECOMPILE_PROTOS=true
   fast_finish: true


### PR DESCRIPTION
Modify the Travis test runs to include allowed-to-fail tests where:
- Dependencies are updated.
- The protos are regenerated using the latest protoc-gen-go.

Notice that the test for regenerating protos will actually fail in this pull request. This is fixed separately in #25.