### PR TITLE
Remove constraints to use the "master" branch from Gopkg.toml

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -1,11 +1,3 @@
-[[constraint]]
-  branch = "master"
-  name = "github.com/benlaurie/objecthash"
-
-[[constraint]]
-  branch = "master"
-  name = "github.com/golang/protobuf"
-
 [prune]
   go-tests = true
   unused-packages = true


### PR DESCRIPTION
This is in order to avoid enforcing unnecessary restrictions on users of
this package.